### PR TITLE
PodProgramar w/ Jessi Zanelato and Ana Eliza

### DIFF
--- a/data/podcasts.json
+++ b/data/podcasts.json
@@ -273,5 +273,16 @@
         "updates": "Weekly/Seasonal",
         "broadcast": "Monday",
         "logo": "https://irlpodcast.org/images/episodes/S01E00/artwork.png"
+    },
+    {
+        "name": "PodProgramar",
+        "host": "Jessi Zanelato",
+        "url": "https://mundopodcast.com.br/podprogramar",
+        "category": "News, Programming",
+        "description": "Podcast presented by developers Jessi Zanelato and Ana Eliza, focused on programming, news and stories from the area, everything with feminine touch in an area dominated by men.",
+        "languages": "Portuguese",
+        "updates": "Irregular",
+        "broadcast": "Irregular",
+        "logo": "https://i.imgur.com/Dqu4mSH.jpg"
     }
 ]


### PR DESCRIPTION
Podcast presented by developers Jessi Zanelato and Ana Eliza, focused on programming, news and stories from the area, everything with feminine touch in an area dominated by men.